### PR TITLE
Add example or template for easier .env file creation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+BASE_URL=http://localhost:3000
+
+DB_USERNAME=postgres
+DB_PASSWORD=yourpassword
+DB_DATABASE=ikat_digital
+DB_HOST=localhost
+DB_PORT=5432

--- a/README.md
+++ b/README.md
@@ -75,18 +75,15 @@ See our [Disclaimer](https://ikat.id/disclaimer) for more information.
 
 ```
 
-3. Create a `.env` file:
+3. Create a `.env` file by copying from `.env.example`:
 
 ```env
 
-   DB_USERNAME=postgres
-   DB_PASSWORD=yourpassword
-   DB_DATABASE=ikat_digital
-   DB_HOST=localhost
-   DB_PORT=5432
-   BASE_URL=http://localhost:3000
+   cp .env.example .env
 
 ```
+
+Adjust the configuration accordingly.
 
 4. Create and migrate the database:
 
@@ -135,4 +132,3 @@ MIT License © 2025 — [Liu Purnomo](https://liupurnomo.com)
 * 📸 [Instagram](https://instagram.com/liupurnomo)
 * 💼 [LinkedIn](https://linkedin.com/in/liupurnomo)
 * 📺 [YouTube](https://youtube.com/@liupurnomo)
-


### PR DESCRIPTION
Hi! I want to propose a change to make running locally process easier.

Instead of making the users creating the `.env` file manually, we provide a template or example file for them to copy and then they can adjust the configuration.